### PR TITLE
docs: Update to openshift-install 0.8.0

### DIFF
--- a/docs/01-prerequisites.md
+++ b/docs/01-prerequisites.md
@@ -4,18 +4,16 @@
 
 1. Visit [https://try.openshift.com](https://try.openshift.com) with your web browser
 1. Login with a Red Hat Account
-1. Download the Pull Secret to location on host (e.g. ~/Downloads/pull-secret)
+1. Download the Pull Secret to a location on your host (e.g. `~/Downloads/pull-secret`)
 1. Download the Installer release for your platform
 1. Download Terraform
 1. Download OpenShift client tools
 
 ### Linux
 
-```
-wget https://github.com/openshift/installer/releases/download/v0.4.0/openshift-install-linux-amd64
+```sh
+wget https://github.com/openshift/installer/releases/download/v0.8.0/openshift-install-linux-amd64
 chmod u+x ./openshift-install-linux-amd64
-export OPENSHIFT_INSTALL_PULL_SECRET_PATH=~/Downloads/pull-secret
-curl -L "https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_linux_amd64.zip" | funzip terraform
 wget https://mirror.openshift.com/pub/openshift-v3/clients/4.0.0-0.79.0/linux/oc.tar.gz
 tar -xvf oc.tar.gz
 ```
@@ -23,9 +21,8 @@ tar -xvf oc.tar.gz
 ### Mac
 
 ```
-curl -O -L https://github.com/openshift/installer/releases/download/v0.4.0/openshift-install-darwin-amd64
+curl -O -L https://github.com/openshift/installer/releases/download/v0.8.0/openshift-install-darwin-amd64
 chmod +x ./openshift-install-darwin-amd64
-export OPENSHIFT_INSTALL_PULL_SECRET_PATH=~/Downloads/pull-secret
 curl -L https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_darwin_amd64.zip | funzip terraform
 ```
 

--- a/docs/02-install.md
+++ b/docs/02-install.md
@@ -7,7 +7,7 @@ cannot determine on its own and providing reasonable defaults for everything
 else. For more advanced users, the installer provides facilities for varying
 levels of customization.
 
-In [supported environments](#supported-environments), the installer is also
+In [supported environments][supported-environments], the installer is also
 capable of provisioning the underlying infrastructure for the cluster. It is
 recommended that most users make use of this functionality in order to avoid
 having to provision their own infrastructure. In unsupported environments or
@@ -20,9 +20,8 @@ installer.
 
 In the prior step, we downloaded the following:
 
-1. installer (e.g. openshift-install-linux-amd64)
-1. pull secret
-1. configured env var for OPENSHIFT_PULL_SECRET_PATH
+1. installer (e.g. `openshift-install-linux-amd64`)
+1. pull secret (e.g. `~/Downloads/pull-secret`)
 
 ## Wizard
 
@@ -80,49 +79,11 @@ INFO kubeadmin user password: Seiv2-q9xJW-2rHR2-UGRRj
 INFO Install complete! The kubeconfig is located here: /home/decarr/go/src/github.com/openshift/installer/auth/kubeconfig
 ```
 
-## Populated Answers
+## Multiple Invocations
 
-If you want to avoid the wizard, its useful to setup a set of env vars for a
-particular cloud platform.
-
-### Amazon Web Services
-
-#### Linux
-
-```
-## location of previously downloaded pull secret
-export OPENSHIFT_INSTALL_PULL_SECRET_PATH=~/Downloads/pull-secret
-## location of SSH public key
-export OPENSHIFT_INSTALL_SSH_PUB_KEY_PATH=~/.ssh/id_rsa.pub
-export OPENSHIFT_INSTALL_PLATFORM=aws
-export OPENSHIFT_INSTALL_EMAIL_ADDRESS=user@example.com
-## name of cluster
-export OPENSHIFT_INSTALL_CLUSTER_NAME=my-cluster
-export OPENSHIFT_INSTALL_PASSWORD=my-password
-export OPENSHIFT_INSTALL_AWS_REGION=us-east-2
-export OPENSHIFT_INSTALL_BASE_DOMAIN=devcluster.example.com
-./openshift-install-linux-amd64 create cluster
-```
-
-#### Mac
-
-```
-## location of previously downloaded pull secret
-export OPENSHIFT_INSTALL_PULL_SECRET_PATH=~/Downloads/pull-secret
-## location of SSH public key
-export OPENSHIFT_INSTALL_SSH_PUB_KEY_PATH=~/.ssh/id_rsa.pub
-export OPENSHIFT_INSTALL_PLATFORM=aws
-export OPENSHIFT_INSTALL_EMAIL_ADDRESS=user@example.com
-## name of cluster
-export OPENSHIFT_INSTALL_CLUSTER_NAME=my-cluster
-export OPENSHIFT_INSTALL_PASSWORD=my-password
-export OPENSHIFT_INSTALL_AWS_REGION=us-east-2
-export OPENSHIFT_INSTALL_BASE_DOMAIN=devcluster.example.com
-./openshift-install-darwin-amd64 create cluster
-```
-
-## Supported Environments
-
-- AWS
+If you want to avoid the wizard in future runs, you can [save the generated `install-config.yaml` and reuse it later][multiple-invocations].
 
 Next: [Exploring the Cluster](03-explore.md)
+
+[multiple-invocations]: https://github.com/openshift/installer/blob/master/docs/user/overview.md#multiple-invocations
+[supported-environments]: https://github.com/openshift/installer/blob/master/README.md#supported-platforms


### PR DESCRIPTION
A few changes:

* Backticks for some code like `~/Downloads/pull-secret`.  This change is not exhaustive.
* Drop environment variables to catch up with openshift/installer@6be4c253 (openshift/installer#861).
* Link to the installer repository for a list of supported platforms.
* Link to the installer repository for discussion of repeat calls, since that seems useful, but out-of-scope for a workshop-length introduction.  The linked docs will get fleshed out a bit once openshift/installer#935 unifies the existing docs there with the current tips-and-trics stuff.

CC @chancez